### PR TITLE
Set method accessibility to private to keep convention

### DIFF
--- a/plugins/folder-manager/FolderItem.vala
+++ b/plugins/folder-manager/FolderItem.vala
@@ -78,7 +78,7 @@ namespace Scratch.Plugins.FolderManager {
             return menu;
         }*/
 
-        internal void add_children () {
+        private void add_children () {
             foreach (var child in file.children) {
                 if (child.is_valid_directory) {
                     var item = new FolderItem (child, view);


### PR DESCRIPTION
There's no reason why this should be any different from the other methods.