### PR TITLE
Fix #146 - Add checks for null current document where necessary

### DIFF
--- a/plugins/browser-preview/browser-preview.vala
+++ b/plugins/browser-preview/browser-preview.vala
@@ -130,6 +130,9 @@ namespace Scratch.Plugins {
         }
 
         void show_preview () {
+            if (this.doc == null) {
+                return;
+            }
 
             bool tab_is_selected = false;
             int tab_page_number = 0;

--- a/plugins/strip-trailing-save/strip-trailing-save.vala
+++ b/plugins/strip-trailing-save/strip-trailing-save.vala
@@ -30,7 +30,7 @@ public class Scratch.Plugins.StripTrailSave: Peas.ExtensionBase, Peas.Activatabl
      * Activate plugin.
      */
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;   
+        plugins = (Scratch.Services.Interface) object;
         plugins.hook_window.connect ((w) => {
             this.main_window = w;
             w.main_actions.pre_activate.connect (on_save);
@@ -49,7 +49,7 @@ public class Scratch.Plugins.StripTrailSave: Peas.ExtensionBase, Peas.Activatabl
      * Strip trailing spaces in document.
      */
     void on_save (Gtk.Action action) {
-        if (action==action_save) {
+        if (action == action_save && main_window.get_current_document () != null) {
             var text_view = main_window.get_current_document ().source_view;
             var buffer = text_view.buffer;
             buffer.begin_user_action();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -731,32 +731,49 @@ namespace Scratch {
         }
 
         private void action_save () {
-            var doc = get_current_document ();
-            if (doc.is_file_temporary == true) {
-                action_save_as ();
-            } else {
-                doc.save.begin ();
+            var doc = get_current_document (); /* may return null */
+            if (doc != null) {
+                if (doc.is_file_temporary == true) {
+                    action_save_as ();
+                } else {
+                    doc.save.begin ();
+                }
             }
         }
 
         private void action_save_as () {
-            get_current_document ().save_as.begin ();
+            var doc = get_current_document ();
+            if (doc != null) {
+                doc.save_as.begin ();
+            }
         }
 
         private void action_undo () {
-            get_current_document ().undo ();
+            var doc = get_current_document ();
+            if (doc != null) {
+                doc.undo ();
+            }
         }
 
         private void action_redo () {
-            get_current_document ().redo ();
+            var doc = get_current_document ();
+            if (doc != null) {
+                doc.redo ();
+            }
         }
 
         private void action_revert () {
-            get_current_document ().revert ();
+            var doc = get_current_document ();
+            if (doc != null) {
+                doc.revert ();
+            }
         }
 
         private void action_duplicate () {
-            get_current_document ().duplicate_selection ();
+            var doc = get_current_document ();
+            if (doc != null) {
+                doc.duplicate_selection ();
+            }
         }
 
         private void action_new_tab () {

--- a/src/Widgets/SearchManager.vala
+++ b/src/Widgets/SearchManager.vala
@@ -53,7 +53,7 @@ namespace Scratch.Widgets {
          * color
          */
         private Gdk.RGBA normal_color;
-        
+
         public signal void need_hide ();
 
         /**
@@ -135,7 +135,7 @@ namespace Scratch.Widgets {
             replace_entry.activate.connect (on_replace_entry_activate);
             replace_entry.key_press_event.connect (on_replace_entry_key_press);
 
-            // Get default text color in Gtk.Entry 
+            // Get default text color in Gtk.Entry
             var entry_context = new Gtk.StyleContext ();
             var entry_path = new Gtk.WidgetPath ();
             entry_path.append_type (typeof (Gtk.Widget));
@@ -224,7 +224,7 @@ namespace Scratch.Widgets {
         }
 
         private void on_replace_all_entry_activate () {
-            if (text_buffer == null) {
+            if (text_buffer == null || this.window.get_current_document () == null) {
                 debug ("No valid buffer to replace");
                 return;
             }
@@ -352,7 +352,7 @@ namespace Scratch.Widgets {
                     text_buffer.get_end_iter (out start_iter);
                     search_for_iter_backward (start_iter, out end_iter);
                 }
-                
+
                 update_tool_arrows (search_string);
             }
         }
@@ -387,9 +387,9 @@ namespace Scratch.Widgets {
 
                     text_buffer.get_start_iter (out tmp_start_iter);
                     text_buffer.get_end_iter (out tmp_end_iter);
-                    
+
                     text_buffer.get_selection_bounds (out start_iter, out end_iter);
-                    
+
                     is_in_start = start_iter.compare(tmp_start_iter) == 0;
                     is_in_end = end_iter.compare(tmp_end_iter) == 0;
 


### PR DESCRIPTION
Fixes #146 by checking for possible null returned by MainWindow.get_current_document () in one place and takes the opportunity to add similar checks in other places where missing (even if null is unlikely).