### PR TITLE
Sane defaults for word completion

### DIFF
--- a/plugins/word-completion/completion-provider.vala
+++ b/plugins/word-completion/completion-provider.vala
@@ -114,8 +114,7 @@ public class Scratch.Plugins.CompletionProvider : Gtk.SourceCompletionProvider, 
     }
 
     public int get_interactive_delay () {
-        /* Use default delay (250 milliseconds) */
-        return -1;
+        return 0;
     }
 
     public bool get_start_iter (Gtk.SourceCompletionContext context,

--- a/plugins/word-completion/engine.vala
+++ b/plugins/word-completion/engine.vala
@@ -19,7 +19,7 @@
  */
 
 public class Euclide.Completion.Parser : GLib.Object {
-    public const int MINIMUM_WORD_LENGTH = 3;
+    public const int MINIMUM_WORD_LENGTH = 1;
     public const int MAX_TOKENS = 1000000;
 
     public const string delimiters = " .,;:?{}[]()0123456789+-=&|-<>*\\/\n\t\'\"";

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -87,7 +87,6 @@ public class Scratch.Plugins.Completion : Peas.ExtensionBase,  Peas.Activatable 
         if (text_view_list.find (current_view) == null)
             text_view_list.append (current_view);
 
-
         var comp_provider = new Scratch.Plugins.CompletionProvider (this);
         comp_provider.priority = 1;
         comp_provider.name = provider_name_from_document (doc);
@@ -95,7 +94,7 @@ public class Scratch.Plugins.Completion : Peas.ExtensionBase,  Peas.Activatable 
 
         try {
             current_view.completion.add_provider (comp_provider);
-            current_view.completion.show_headers = true;
+            current_view.completion.show_headers = false;
             current_view.completion.show_icons = true;
             /* Wait a bit to allow text to load then run parser*/
             timeout_id = Timeout.add (1000, on_timeout_update);


### PR DESCRIPTION
Fixes #184.

* Decreases minimum word length to 1.
* Removes the timeout to show completion window completely.
* Hides the "Word completion" header in the completion window.