### PR TITLE
Remove leftover RestoreTab action from UI file

### DIFF
--- a/src/scratch-ui.xml
+++ b/src/scratch-ui.xml
@@ -6,7 +6,6 @@
         <menuitem name="Quit" action="Quit"/>
         <menuitem name="ShowGoTo" action="ShowGoTo"/>
         <menuitem name="ShowReplace" action="ShowReplace"/>
-        <menuitem name="RestoreTab" action="RestoreTab"/>
         <menuitem name="NewTab" action="NewTab"/>
         <menuitem name="NewView" action="NewView"/>
         <menuitem name="Fullscreen" action="Fullscreen"/>


### PR DESCRIPTION
I was having quite a few issues with keyboard accelerators, after removing this line, they all magically went away.

I suspect it's because something was pointing at an action that no longer existed.