### PR TITLE
Convert app menu to use glib.action

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -66,6 +66,7 @@ namespace Scratch {
         public const string ACTION_NEW_VIEW = "action_new_view";
         public const string ACTION_PREFERENCES = "preferences";
         public const string ACTION_REMOVE_VIEW = "action_remove_view";
+        public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
         private const ActionEntry[] action_entries = {
             { ACTION_NEW_VIEW, action_new_view },
@@ -79,13 +80,20 @@ namespace Scratch {
                     icon_name: "accessories-text-editor");
 
             title = app.app_cmd_name;
-            application.set_accels_for_action (ACTION_PREFIX + ACTION_NEW_VIEW, { "F3" });
+        }
+
+        static construct {
+            action_accelerators.set (ACTION_NEW_VIEW, "F3");
         }
 
         construct {
             actions = new SimpleActionGroup ();
             actions.add_action_entries (action_entries, this);
             insert_action_group ("win", actions);
+
+            foreach (var action in action_accelerators.get_keys ()) {
+                app.set_accels_for_action (ACTION_PREFIX + action, action_accelerators[action].to_array ());
+            }
 
             set_size_request (450, 400);
             set_hide_titlebar_when_maximized (false);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -60,6 +60,18 @@ namespace Scratch {
         // Delegates
         delegate void HookFunc ();
 
+        public SimpleActionGroup actions;
+
+        public const string ACTION_NEW_VIEW = "action_new_view";
+        public const string ACTION_PREFERENCES = "preferences";
+        public const string ACTION_REMOVE_VIEW = "action_remove_view";
+
+        private const ActionEntry[] action_entries = {
+            { ACTION_NEW_VIEW, action_new_view },
+            { ACTION_PREFERENCES, action_preferences },
+            { ACTION_REMOVE_VIEW, action_remove_view }
+        };
+
         public MainWindow (Application scratch_app) {
             Object (application: scratch_app,
                     app: scratch_app,
@@ -69,6 +81,10 @@ namespace Scratch {
         }
 
         construct {
+            actions = new SimpleActionGroup ();
+            actions.add_action_entries (action_entries, this);
+            insert_action_group ("win", actions);
+
             set_size_request (450, 400);
             set_hide_titlebar_when_maximized (false);
 
@@ -924,14 +940,6 @@ namespace Scratch {
             { "CloseTab", null, null, "<Control>w", null, action_close_tab },
             { "ShowReplace", null, null, "<Control>r", null, action_fetch },
             { "NewTab", null, null, "<Control>n", null, action_new_tab },
-            { "NewView", "add",
-          /* label, accelerator */       N_("Add New View"), "F3",
-          /* tooltip */                  N_("Add a new view"),
-                                         action_new_view },
-            { "RemoveView", "window-close",
-          /* label, accelerator */       N_("Remove Current View"), null,
-          /* tooltip */                  N_("Remove this view"),
-                                         action_remove_view },
             { "Undo", null, null, "<Control>z", null, action_undo },
             { "Redo", null, null, "<Control><shift>z", null, action_redo },
             { "Revert", null, null, "<Control><shift>o", null, action_revert },
@@ -942,10 +950,6 @@ namespace Scratch {
             { "SaveFile", null, null, "<Control>s", null, action_save },
             { "SaveFileAs", null, null, "<Control><shift>s", null, action_save_as },
             { "Templates", null, null, null, null, action_templates },
-            { "Preferences", "preferences-desktop",
-          /* label, accelerator */       N_("Preferences"), null,
-          /* tooltip */                  N_("Change Scratch settings"),
-                                         action_preferences },
             { "NextTab", null, null, "<Control><Alt>Page_Up", null, action_next_tab },
             { "PreviousTab", null, null, "<Control><Alt>Page_Down", null, action_previous_tab },
             { "ToLowerCase", null, null, "<Control>l", null, action_to_lower_case },

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -60,8 +60,9 @@ namespace Scratch {
         // Delegates
         delegate void HookFunc ();
 
-        public SimpleActionGroup actions;
+        public SimpleActionGroup actions { get; construct; }
 
+        public const string ACTION_PREFIX = "win.";
         public const string ACTION_NEW_VIEW = "action_new_view";
         public const string ACTION_PREFERENCES = "preferences";
         public const string ACTION_REMOVE_VIEW = "action_remove_view";
@@ -78,6 +79,7 @@ namespace Scratch {
                     icon_name: "accessories-text-editor");
 
             title = app.app_cmd_name;
+            application.set_accels_for_action (ACTION_PREFIX + ACTION_NEW_VIEW, { "F3" });
         }
 
         construct {

--- a/src/Widgets/SplitView.vala
+++ b/src/Widgets/SplitView.vala
@@ -227,8 +227,8 @@ namespace Scratch.Widgets {
 
         // Check the possibility to add or not a new view
         private void check_actions () {
-            ((SimpleAction) window.actions.lookup_action ("action_new_view")).set_enabled (views.length () < 2);
-            ((SimpleAction) window.actions.lookup_action ("action_remove_view")).set_enabled (views.length () > 1);
+            ((SimpleAction) window.actions.lookup_action (MainWindow.ACTION_NEW_VIEW)).set_enabled (views.length () < 2);
+            ((SimpleAction) window.actions.lookup_action (MainWindow.ACTION_REMOVE_VIEW)).set_enabled (views.length () > 1);
             views_changed (views.length ());
         }
     }

--- a/src/Widgets/SplitView.vala
+++ b/src/Widgets/SplitView.vala
@@ -227,9 +227,8 @@ namespace Scratch.Widgets {
 
         // Check the possibility to add or not a new view
         private void check_actions () {
-            window.main_actions.get_action ("NewView").sensitive = (views.length () < 2);
-            window.main_actions.get_action ("RemoveView").sensitive = (views.length () > 1);
-
+            ((SimpleAction) window.actions.lookup_action ("action_new_view")).set_enabled (views.length () < 2);
+            ((SimpleAction) window.actions.lookup_action ("action_remove_view")).set_enabled (views.length () > 1);
             views_changed (views.length ());
         }
     }

--- a/src/Widgets/ToolBar.vala
+++ b/src/Widgets/ToolBar.vala
@@ -78,13 +78,13 @@ namespace Scratch.Widgets {
             share_app_menu.set_popup (share_menu);
 
             var new_view_menuitem = new Gtk.MenuItem.with_label (_("Add New View"));
-            new_view_menuitem.action_name = "win." + MainWindow.ACTION_NEW_VIEW;
+            new_view_menuitem.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_VIEW;
 
             var remove_view_menuitem = new Gtk.MenuItem.with_label (_("Remove Current View"));
-            remove_view_menuitem.action_name = "win." + MainWindow.ACTION_REMOVE_VIEW;
+            remove_view_menuitem.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_REMOVE_VIEW;
 
             var preferences_menuitem = new Gtk.MenuItem.with_label (_("Preferences"));
-            preferences_menuitem.action_name = "win." + MainWindow.ACTION_PREFERENCES;
+            preferences_menuitem.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_PREFERENCES;
 
             menu = new Gtk.Menu ();
             menu.add (new_view_menuitem);

--- a/src/Widgets/ToolBar.vala
+++ b/src/Widgets/ToolBar.vala
@@ -73,21 +73,30 @@ namespace Scratch.Widgets {
             share_menu = new Gtk.Menu ();
             share_app_menu = new Gtk.MenuButton ();
             share_app_menu.image = new Gtk.Image.from_icon_name ("document-export", Gtk.IconSize.LARGE_TOOLBAR);
+            share_app_menu.no_show_all = true;
             share_app_menu.tooltip_text = _("Share");
             share_app_menu.set_popup (share_menu);
 
+            var new_view_menuitem = new Gtk.MenuItem.with_label (_("Add New View"));
+            new_view_menuitem.action_name = "win." + MainWindow.ACTION_NEW_VIEW;
+
+            var remove_view_menuitem = new Gtk.MenuItem.with_label (_("Remove Current View"));
+            remove_view_menuitem.action_name = "win." + MainWindow.ACTION_REMOVE_VIEW;
+
+            var preferences_menuitem = new Gtk.MenuItem.with_label (_("Preferences"));
+            preferences_menuitem.action_name = "win." + MainWindow.ACTION_PREFERENCES;
+
             menu = new Gtk.Menu ();
-            menu.add (main_actions.get_action ("NewView").create_menu_item () as Gtk.MenuItem);
-            menu.add (main_actions.get_action ("RemoveView").create_menu_item () as Gtk.MenuItem);
+            menu.add (new_view_menuitem);
+            menu.add (remove_view_menuitem);
             menu.add (new Gtk.SeparatorMenuItem ());
-            menu.add (main_actions.get_action ("Preferences").create_menu_item () as Gtk.MenuItem);
+            menu.add (preferences_menuitem);
+            menu.show_all ();
 
             var app_menu = new Gtk.MenuButton ();
             app_menu.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
             app_menu.tooltip_text = _("Menu");
             app_menu.popup = menu;
-
-            share_app_menu.no_show_all = true;
 
             pack_start (open_button);
             pack_start (templates_button);
@@ -108,7 +117,8 @@ namespace Scratch.Widgets {
 
             settings.changed.connect (() => {
                 save_button.visible = !settings.autosave;
-                zoom_default.visible = Application.instance.get_last_window ().get_default_font_size () != Application.instance.get_last_window ().get_current_font_size ();
+                var last_window = Application.instance.get_last_window ();
+                zoom_default.visible = last_window.get_default_font_size () != last_window.get_current_font_size ();
             });
 
         }


### PR DESCRIPTION
Adds a SimpleActionGroup and converts the app menu from using the deprecated Gtk.Action to GLib.action