### PR TITLE
Object disambiguate

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -25,7 +25,7 @@ namespace Scratch {
         public int FONT_SIZE_MIN = 7;
         private const uint MAX_SEARCH_TEXT_LENGTH = 255;
 
-        public weak Application app { get; construct; }
+        public weak Scratch.Application app { get; construct; }
 
         // Widgets
         public Scratch.Widgets.Toolbar toolbar;
@@ -60,12 +60,13 @@ namespace Scratch {
         // Delegates
         delegate void HookFunc ();
 
-        public MainWindow (Application scratch_app) {
-            Object (application: scratch_app,
-                    app: scratch_app,
-                    icon_name: "accessories-text-editor");
-
-            title = app.app_cmd_name;
+        public MainWindow (Scratch.Application application) {
+            Object (
+                application: application,
+                app: application,
+                icon_name: "io.elementary.code",
+                title: _("Code")
+            );
         }
 
         construct {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -60,10 +60,10 @@ namespace Scratch {
         // Delegates
         delegate void HookFunc ();
 
-        public MainWindow (Scratch.Application application) {
+        public MainWindow (Scratch.Application scratch_app) {
             Object (
-                application: application,
-                app: application,
+                application: scratch_app,
+                app: scratch_app,
                 icon_name: "io.elementary.code",
                 title: _("Code")
             );


### PR DESCRIPTION
* disambiguate between Gtk.Application and Scratch.Application so that it's clearer what we're actually setting in the object

While we're here:
* Make default title translatable and fix icon name
* code style