### PR TITLE
Fix file name for pot generation

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -6,5 +6,5 @@ add_translations_catalog (${GETTEXT_PACKAGE}
     DESKTOP_FILES
         ${CMAKE_SOURCE_DIR}/data/org.pantheon.scratch.desktop.in
     APPDATA_FILES
-        ${CMAKE_SOURCE_DIR}/data/org.pantheon.scratch.appdata.xml.in
+        ${CMAKE_SOURCE_DIR}/data/io.elementary.code.appdata.xml.in
 )


### PR DESCRIPTION
This file was renamed but cmake wasn't updated so pot generation fails