### PR TITLE
Fix regression with loading view centering

### DIFF
--- a/src/Widgets/LoadingView.vala
+++ b/src/Widgets/LoadingView.vala
@@ -32,6 +32,7 @@ namespace Scratch.Widgets {
 
             var label = new Gtk.Label (_("Wait while restoring last session..."));
             label.margin = 12;
+            label.hexpand = true;
 
             var grid = new Gtk.Grid ();
             grid.orientation = Gtk.Orientation.VERTICAL;


### PR DESCRIPTION
This regression was introduced by #172. The loading view was centered before, but the change from `Gtk.Box` to `Gtk.Grid` affected the centering of the text and the spinner in the loading view. 