### PR TITLE
Ensure order of focus_in_event handlers (#228)

### DIFF
--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -241,7 +241,7 @@ public class Scratch.Widgets.DocumentView : Gtk.Box {
         doc.actions = window.actions;
 
         docs.append (doc);
-        doc.source_view.focus_in_event.connect (on_focus_in_event);
+        doc.source_view.focus_in_event.connect_after (on_focus_in_event);
         doc.source_view.drag_data_received.connect (drag_received);
     }
 


### PR DESCRIPTION
Following the introduction of asynchronous loading, the order in which two handlers connected to the source_view focus-in-event signal was unexpectedly changed.  This had the unexpected effect of disabling the (now) second handler since the (now) first handler returns true.  To fix this handler that must be called second is connected using ```connect_after``` to ensure the correct order of calling.