### PR TITLE
Improve handling of problematic files

### DIFF
--- a/plugins/contractor/contractor.vala
+++ b/plugins/contractor/contractor.vala
@@ -1,21 +1,21 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /***
   BEGIN LICENSE
-	
+
   Copyright (C) 2011-2013 Mario Guerriero <mario@elementaryos.org>
-  This program is free software: you can redistribute it and/or modify it	
-  under the terms of the GNU Lesser General Public License version 3, as published	
+  This program is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
-	
-  This program is distributed in the hope that it will be useful, but	
-  WITHOUT ANY WARRANTY; without even the implied warranties of	
-  MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR	
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranties of
+  MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
   PURPOSE.  See the GNU General Public License for more details.
-	
-  You should have received a copy of the GNU General Public License along	
-  with this program.  If not, see <http://www.gnu.org/licenses/>	
-  
-  END LICENSE	
+
+  You should have received a copy of the GNU General Public License along
+  with this program.  If not, see <http://www.gnu.org/licenses/>
+
+  END LICENSE
 ***/
 
 public const string DESCRIPTION = _("Share your files with Contractor");
@@ -58,7 +58,7 @@ public class Scratch.Plugins.Contractor : Peas.ExtensionBase,  Peas.Activatable 
         plugins = (Scratch.Services.Interface) object;
         plugins.hook_share_menu.connect (on_hook);
     }
-    
+
     public void deactivate () {
         foreach (var item in list) {
             var parent = item.get_parent ();
@@ -69,7 +69,7 @@ public class Scratch.Plugins.Contractor : Peas.ExtensionBase,  Peas.Activatable 
 
         list.clear ();
     }
-    
+
     private void on_hook (Gtk.Menu menu) {
         plugins.hook_document.connect ((doc) => {
             // Remove old contracts
@@ -86,7 +86,7 @@ public class Scratch.Plugins.Contractor : Peas.ExtensionBase,  Peas.Activatable 
 
             // Create ContractorMenu widget
             try {
-                var contracts = Granite.Services.ContractorProxy.get_contracts_by_mime (doc.get_mime_type ());
+                var contracts = Granite.Services.ContractorProxy.get_contracts_by_mime (doc.mime_type);
                 foreach (var contract in contracts) {
                     var menu_item = new ContractMenuItem (contract, doc.file);
                     menu.append (menu_item);
@@ -98,7 +98,7 @@ public class Scratch.Plugins.Contractor : Peas.ExtensionBase,  Peas.Activatable 
             }
         });
     }
-    
+
 }
 
 [ModuleInit]

--- a/plugins/outline/OutlinePlugin.vala
+++ b/plugins/outline/OutlinePlugin.vala
@@ -50,7 +50,7 @@ namespace Scratch.Plugins {
         }
 
         public void update_state () {
-            
+
         }
 
         void on_hook_sidebar (Gtk.Stack sidebar) {
@@ -77,7 +77,7 @@ namespace Scratch.Plugins {
             }
 
             if (view == null && doc.file != null) {
-                var mime_type = doc.get_mime_type ();
+                var mime_type = doc.mime_type;
                 switch (mime_type) {
                     case "text/x-vala":
                         view = new ValaSymbolOutline (doc);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -221,11 +221,7 @@ namespace Scratch {
             Unix.signal_add (Posix.SIGINT, quit_source_func, Priority.HIGH);
             Unix.signal_add (Posix.SIGTERM, quit_source_func, Priority.HIGH);
 
-            /* Showing welcome sets widgets insensitive.
-             * Welcome view will be removed and the widgets set sensitive
-             * if a document is successfully loaded.
-             */
-            split_view.show_welcome ();
+            /* Splitview controls showing and hiding of Welcome view */
         }
 
         private void init_layout () {
@@ -402,13 +398,16 @@ namespace Scratch {
         private void load_files_for_view (Scratch.Widgets.DocumentView view, string[] uris) {
             foreach (string uri in uris) {
                if (uri != "") {
-                    var file = File.new_for_uri (uri);
-                    if (file.query_exists ()) {
-                        var doc = new Scratch.Services.Document (actions, file);
-
-                        if (!doc.is_file_temporary || doc.exists ()) {
-                            open_document (doc, view);
-                        }
+                    GLib.File file;
+                    if (Uri.parse_scheme (uri) != null) {
+                        file = File.new_for_uri (uri);
+                    } else {
+                        file = File.new_for_commandline_arg (uri);
+                    }
+                    /* Leave it to doc to handle problematic files properly */
+                    var doc = new Scratch.Services.Document (actions, file);
+                    if (!doc.is_file_temporary) {
+                        open_document (doc, view);
                     }
                 }
             }
@@ -523,14 +522,14 @@ namespace Scratch {
         }
 
         // Show LoadingView
-        public void start_loading () {
+        private void start_loading () {
             loading_view.start ();
             vp.visible = false;
             toolbar.sensitive = false;
         }
 
         // Hide LoadingView
-        public void stop_loading () {
+        private void stop_loading () {
             loading_view.stop ();
             vp.visible = true;
             toolbar.sensitive = true;

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -62,6 +62,28 @@ namespace Scratch.Services {
             }
         }
 
+        private string? _mime_type = null;
+        public string? mime_type {
+            get {
+                if (_mime_type == null) {
+                    try {
+                        var info = file.query_info ("standard::*", FileQueryInfoFlags.NONE, null);
+                        var content_type = info.get_content_type ();
+                        _mime_type = ContentType.get_mime_type (content_type);
+                        return mime_type;
+                    } catch (Error e) {
+                        debug (e.message);
+                    }
+                }
+
+                if (_mime_type == null) {
+                    _mime_type = "undefined";
+                }
+
+                return _mime_type;
+            }
+        }
+
         public Scratch.Widgets.SourceView source_view;
         public string original_content;
         public bool saved = true;
@@ -151,9 +173,18 @@ namespace Scratch.Services {
             }
         }
 
+        private uint load_timout_id = 0;
         public async bool open () {
+            /* Loading improper files may hang so we cancel after a certain time as a fallback.
+             * In most cases, an error will be thrown and caught. */
+            if (load_cancellable != null) { /* just in case */
+                load_cancellable.cancel ();
+            }
+
+            load_cancellable = new Cancellable ();
+
             // If it does not exists, let's create it!
-            if (!exists ()) {
+            if (!exists (load_cancellable)) {
                 try {
                     FileUtils.set_contents (file.get_path (), "");
                 } catch (FileError e) {
@@ -165,44 +196,14 @@ namespace Scratch.Services {
             this.working = true;
             loaded = false;
 
-            /* Loading improper files may hang so we cancel after a certain time as a fallback.
-             * In most cases, an error will be thrown and caught. */
-            if (load_cancellable != null) { /* just in case */
-                load_cancellable.cancel ();
-            }
-
-            string content_type = ContentType.from_mime_type (get_mime_type ());
-
+            var content_type = ContentType.from_mime_type (mime_type);
             if (!(ContentType.is_a (content_type, "text/plain"))) {
-
                 var primary_format = _("%s is not a text file.");
                 var secondary_text = _("Code will not load this type of file");
 
-#if GRANITE_MESSAGEDIALOG
-                var dialog = new Granite.MessageDialog (primary_format.printf (this.get_basename ()),
-                                                        secondary_text,
-                                                        new ThemedIcon.with_default_fallbacks ("dialog-warning"));
-#else
-                var dialog = new Gtk.MessageDialog ((Gtk.Window?)source_view.get_toplevel (),
-                                                    Gtk.DialogFlags.MODAL,
-                                                    Gtk.MessageType.WARNING,
-                                                    Gtk.ButtonsType.CANCEL,
-                                                    "");
-
-
-                dialog.deletable = false;
-                dialog.use_markup = true;
-
-                dialog.text = ("<b>" + primary_format + "</b>").printf (this.get_basename ());
-                dialog.format_secondary_markup (secondary_text);
-#endif
-                source_view.visible = false;
-                dialog.run ();
-                dialog.destroy ();
+                show_error_dialog (primary_format, secondary_text);
                 return false;
             }
-
-            load_cancellable = new Cancellable ();
 
             while (Gtk.events_pending ()) {
                 Gtk.main_iteration ();
@@ -210,19 +211,38 @@ namespace Scratch.Services {
 
             var buffer = new Gtk.SourceBuffer (null); /* Faster to load into a separate buffer */
 
+            load_timout_id = Timeout.add_seconds_full (GLib.Priority.HIGH, 5, () => {
+                if (load_cancellable != null && !load_cancellable.is_cancelled ()) {
+                    var primary_format = _("Loading file \"%s\" is taking a long time.");
+
+                    if (confirm_cancel_dialog (primary_format)) {
+                        load_timout_id = 0;
+                        load_cancellable.cancel ();
+                        return false;
+                    } else {
+                        return true;
+                    }
+                }
+
+                load_timout_id = 0;
+                return false;
+            });
+
             try {
                 var source_file_loader = new Gtk.SourceFileLoader (buffer, source_file);
                 yield source_file_loader.load_async (GLib.Priority.LOW, load_cancellable, null);
-
                 source_view.set_text (buffer.text);
                 loaded = true;
             } catch (Error e) {
                 critical (e.message);
                 source_view.buffer.text = "";
-                show_error_dialog ();
+                show_default_load_error_dialog ();
                 return false;
             } finally {
                 load_cancellable = null;
+                if (load_timout_id > 0) {
+                    Source.remove (load_timout_id);
+                }
             }
 
             /* Successful load - now do rest of set up */
@@ -251,7 +271,7 @@ namespace Scratch.Services {
 
 #if HAVE_ZEITGEIST
             // Zeitgeist integration
-            zg_log.open_insert (file.get_uri (), get_mime_type ());
+            zg_log.open_insert (file.get_uri (), mime_type);
 #endif
             // Grab focus
             this.source_view.grab_focus ();
@@ -343,7 +363,7 @@ namespace Scratch.Services {
                 delete_backup ();
 #if HAVE_ZEITGEIST
                 // Zeitgeist integration
-                zg_log.close_insert (file.get_uri (), get_mime_type ());
+                zg_log.close_insert (file.get_uri (), mime_type);
 #endif
                 doc_closed ();
             }
@@ -374,7 +394,7 @@ namespace Scratch.Services {
             source_view.buffer.set_modified (false);
 #if HAVE_ZEITGEIST
             // Zeitgeist integration
-            zg_log.save_insert (file.get_uri (), get_mime_type ());
+            zg_log.save_insert (file.get_uri (), mime_type);
 #endif
 
             doc_saved ();
@@ -439,22 +459,10 @@ namespace Scratch.Services {
 
 #if HAVE_ZEITGEIST
             // Zeitgeist integration
-            zg_log.move_insert (file.get_uri (), new_dest.get_uri (), get_mime_type ());
+            zg_log.move_insert (file.get_uri (), new_dest.get_uri (), mime_type);
 #endif
 
             return true;
-        }
-
-        // Get mime type for the document
-        public string get_mime_type () {
-            try {
-                var info = file.query_info ("standard::*", FileQueryInfoFlags.NONE, null);
-                var mime_type = ContentType.get_mime_type (info.get_attribute_as_string (FileAttribute.STANDARD_CONTENT_TYPE));
-                return mime_type;
-            } catch (Error e) {
-                debug (e.message);
-                return "undefined";
-            }
         }
 
         private void restore_settings () {
@@ -622,27 +630,68 @@ namespace Scratch.Services {
             this.source_view.duplicate_selection ();
         }
 
+        /** primary format must contain a single %s where the file basename will be printed (in bold) **/
+        private Gtk.Dialog get_modal_dialog (string primary_format, string secondary_text) {
+            string message =  primary_format.printf ("<b>%s</b>".printf (get_basename ()));
+#if GRANITE_MESSAGEDIALOG
+            var dialog = new Granite.MessageDialog (message,
+                                                    secondary_text,
+                                                    new ThemedIcon.with_default_fallbacks ("dialog-warning"),
+                                                    Gtk.ButtonsType.NONE);
+
+#else
+            var dialog = new Gtk.MessageDialog ((Gtk.Window?)source_view.get_toplevel (),
+                                                Gtk.DialogFlags.MODAL,
+                                                Gtk.MessageType.WARNING,
+                                                Gtk.ButtonsType.NONE,
+                                                "");
+
+
+            dialog.deletable = false;
+            dialog.use_markup = true;
+
+            dialog.text = (message);
+            dialog.format_secondary_markup (secondary_text);
+#endif
+            return dialog;
+        }
+
+        private bool confirm_cancel_dialog (string primary_format) {
+
+            string secondary_text = _("Do you wish to continue or cancel?");
+
+            var dialog = get_modal_dialog (primary_format, secondary_text);
+            dialog.add_button (_("Continue"), Gtk.ResponseType.CANCEL);
+            dialog.add_button (_("Cancel"), Gtk.ResponseType.YES);
+            dialog.run ();
+
+            var res = dialog.run ();
+            dialog.destroy ();
+
+            return res == Gtk.ResponseType.YES;
+        }
+
         // Show an error dialog which says "Hey, I cannot read that file!"
-        private void show_error_dialog () {
+        private void show_default_load_error_dialog () {
+            string primary_format = _("File \"%s\" cannot be read.");
+            string secondary_text = _("Maybe it is corrupt or you do not have the necessary permissions to read it.");
+
+            show_error_dialog (primary_format, secondary_text);
+        }
+
+        /** @primary_format must contain a single %s where the filename will be displayed **/
+        private void show_error_dialog (string primary_format, string secondary_text) {
             if (this.error_shown) {
                 return;
             }
 
             this.error_shown = true;
 
-            var parent_window = source_view.get_toplevel () as Gtk.Window;
-            /* Using ".with_markup () " constructor does not work properly */
-            /* FIXME: This dialog needs changing to Elementary HIG style */
-            var dialog = new Gtk.MessageDialog  (parent_window,
-                                                 Gtk.DialogFlags.MODAL,
-                                                 Gtk.MessageType.ERROR,
-                                                 Gtk.ButtonsType.CLOSE, null);
-
-            /* Setting markup now works */
-            dialog.set_markup ( _("File \"%s\" cannot be read. Maybe it is corrupt\nor you do not have the necessary permissions to read it.").printf ("<b>%s</b>".printf (get_basename ())));
+            var dialog = get_modal_dialog (primary_format, secondary_text);
+            dialog.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
+            source_view.visible = false;
             dialog.run ();
             dialog.destroy ();
-            this.close ();
         }
 
         // Check if the file was deleted/changed by an external source
@@ -695,7 +744,7 @@ namespace Scratch.Services {
                         source_file_loader.load_async.end (res);
                     } catch (Error e) {
                         critical (e.message);
-                        show_error_dialog ();
+                        show_default_load_error_dialog ();
                         return;
                     }
 
@@ -816,8 +865,8 @@ namespace Scratch.Services {
         }
 
         // Return true if the file exists
-        public bool exists () {
-            return this.file.query_exists ();
+        public bool exists (Cancellable? cancellable = null) {
+            return this.file.query_exists (cancellable); /* May block */
         }
 
         private void file_changed () {

--- a/src/Widgets/SplitView.vala
+++ b/src/Widgets/SplitView.vala
@@ -90,6 +90,7 @@ namespace Scratch.Widgets {
 
             views = new GLib.List<Scratch.Widgets.DocumentView> ();
             hidden_views = new GLib.List<Scratch.Widgets.DocumentView> ();
+            show_welcome ();
         }
 
         public Scratch.Widgets.DocumentView? add_view () {
@@ -108,8 +109,7 @@ namespace Scratch.Widgets {
                 view = new Scratch.Widgets.DocumentView (window);
 
                 view.empty.connect (() => {
-                    remove_view (view);
-                    show_welcome ();
+                    remove_view (view); /* Welcome will show if no views left */
                 });
             } else {
                 view = hidden_views.nth_data (0);
@@ -205,7 +205,7 @@ namespace Scratch.Widgets {
             return (views.length () == 0);
         }
 
-        public void show_welcome () {
+        private void show_welcome () {
             pack1 (welcome_screen, true, true);
             welcome_screen.show_all ();
             welcome_shown ();


### PR DESCRIPTION
Fixes #232

* Handle filenames without scheme
* Make Document exists() cancellable
* Make Document mime_type a property to avoid re-querying
* Make SplitView solely control showing of Welcome view
* Add timeout to loading with option to continue
* DRY some dialog code