### PR TITLE
Format bar ui changes

### DIFF
--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -47,7 +47,7 @@ public class Code.FormatBar : Gtk.Grid {
         lang_toggle.tooltip_text = _("Syntax Highlighting");
 
         line_toggle = new FormatButton ();
-        line_toggle.icon = new ThemedIcon ("selection-start-symbolic");
+        line_toggle.icon = new ThemedIcon ("view-continuous-symbolic");
         line_toggle.tooltip_text = _("Line number");
 
         add (tab_toggle);
@@ -157,7 +157,7 @@ public class Code.FormatBar : Gtk.Grid {
         buffer.get_iter_at_offset (out iter, position);
 
         var line = iter.get_line () + 1;
-        line_toggle.text = "%d:%d".printf (line, iter.get_line_offset ());
+        line_toggle.text = "%d.%d".printf (line, iter.get_line_offset ());
 
         goto_spin.value = line;
         goto_spin.adjustment.upper = buffer.get_line_count ();

--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -33,8 +33,27 @@ public class Code.FormatBar : Gtk.Grid {
 
     private unowned Scratch.Services.Document? doc = null;
 
+    private const string CSS = """
+        .format-bar {
+            background-color: @bg_color;
+            border-radius: 3px;
+        }
+    """;
+
+    static construct {
+       var provider = new Gtk.CssProvider ();
+        try {
+            provider.load_from_data (CSS, CSS.length);
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        } catch (Error e) {
+            critical (e.message);
+        }
+    }
+
     construct {
-        get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+        var style_context = get_style_context ();
+        style_context.add_class ("format-bar");
+        style_context.add_class (Gtk.STYLE_CLASS_LINKED);
 
         manager = Gtk.SourceLanguageManager.get_default ();
 


### PR DESCRIPTION
Tabs:
* Put the auto-indent switch at the top like in prefs (So we don't have switch, spinbutton, switch)

Syntax Highlighting:
* Remove the sizegroup from the language selection so that Code can be tiled on notebook screens
* Use menuitem style class
* Add margin so selection rectangle doesn't bleed outside of the popover

Line number:
* Use view-continuous icon
* Use "." instead of ":" because that's what the compiler does

Misc
* Margins on popovers are 12 like in dialogs
* Remove unnecessary/unused/default properties
