### PR TITLE
Set Preferences dialog modal before showing (fixes #254)

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -682,6 +682,7 @@ namespace Scratch {
 
         private void action_preferences () {
             var dialog = new Scratch.Dialogs.Preferences (this, plugins);
+            dialog.set_modal (true);
             dialog.show_all ();
         }
 


### PR DESCRIPTION
Sets the preferences dialog to modal before showing (fixes #254).
