### PR TITLE
Accept '.' separator in go-to line entry (#247)

### DIFF
--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -29,7 +29,7 @@ public class Code.FormatBar : Gtk.Grid {
     private Gtk.Switch autoindent_switch;
 
     public FormatButton line_toggle;
-    private Gtk.SpinButton goto_spin;
+    private Gtk.Entry goto_entry;
 
     private unowned Scratch.Services.Document? doc = null;
 
@@ -176,25 +176,23 @@ public class Code.FormatBar : Gtk.Grid {
         var position = buffer.cursor_position;
         Gtk.TextIter iter;
         buffer.get_iter_at_offset (out iter, position);
-
         var line = iter.get_line () + 1;
+        
         line_toggle.text = "%d.%d".printf (line, iter.get_line_offset ());
-
-        goto_spin.value = line;
-        goto_spin.adjustment.upper = buffer.get_line_count ();
+        goto_entry.text = "%d.%d".printf (line, iter.get_line_offset ());
     }
 
     private void create_line_popover () {
         var goto_label = new Gtk.Label (_("Go To Line:"));
         goto_label.xalign = 1;
 
-        goto_spin = new Gtk.SpinButton.with_range (1, 1, 1);
+        goto_entry = new Gtk.Entry ();
 
         var line_grid = new Gtk.Grid ();
         line_grid.margin = 12;
         line_grid.column_spacing = 12;
         line_grid.attach (goto_label, 0, 0, 1, 1);
-        line_grid.attach (goto_spin, 1, 0, 1, 1);
+        line_grid.attach (goto_entry, 1, 0, 1, 1);
         line_grid.show_all ();
 
         var line_popover = new Gtk.Popover (line_toggle);
@@ -203,8 +201,12 @@ public class Code.FormatBar : Gtk.Grid {
 
         line_toggle.bind_property ("active", line_popover, "visible", GLib.BindingFlags.BIDIRECTIONAL);
         // We need to connect_after because otherwise, the text isn't parsed into the "value" property and we only get the previous value
-        goto_spin.activate.connect_after (() => {
-            doc.source_view.go_to_line (goto_spin.get_value_as_int ());
+        goto_entry.activate.connect_after (() => {
+            int line, offset;
+            goto_entry.text.scanf("%i.%i", out line, out offset);
+            doc.source_view.go_to_line (line, offset);
+            // Focuses parent to the source view, so that the cursor, which indicates line and column is actually visible.
+            doc.source_view.grab_focus ();
         });
     }
 

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -182,9 +182,10 @@ namespace Scratch.Widgets {
             style_changed (source_buffer.style_scheme);
         }
 
-        public void go_to_line (int line) {
+        public void go_to_line (int line, int offset = 0) {
             Gtk.TextIter it;
-            buffer.get_iter_at_line (out it, line-1);
+            buffer.get_iter_at_line (out it, line - 1);
+            it.forward_chars (offset);
             scroll_to_iter (it, 0, false, 0, 0);
             buffer.place_cursor (it);
             set_highlight_current_line (true);


### PR DESCRIPTION
- Because the input is now not a single number, `SpinButton` was refactored to `Entry`.  The behavior when the input is invalid is the same as before: it just scrolls to the last line in the document.
- Because the cursor needs to actually be visible, thus the `SourceView` needs to be in focus, `grab_focus` is called after setting the cursor. Possible improvement: hide the go-to tooltip upon scrolling to the desired line.
